### PR TITLE
frontend/feat/#8/conversation_chat_classes: Adding Classes Chat And C…

### DIFF
--- a/LAA/LAA.pro
+++ b/LAA/LAA.pro
@@ -9,10 +9,14 @@ CONFIG += c++17
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 SOURCES += \
+    chat.cpp \
+    conversation.cpp \
     main.cpp \
     mainwindow.cpp
 
 HEADERS += \
+    chat.h \
+    conversation.h \
     mainwindow.h
 
 FORMS += \

--- a/LAA/LAA.pro.user
+++ b/LAA/LAA.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 12.0.0, 2023-12-14T20:18:38. -->
+<!-- Written by QtCreator 12.0.0, 2023-12-16T19:28:42. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -56,6 +56,33 @@
    <value type="bool" key="EditorConfiguration.inEntireDocument">false</value>
    <value type="bool" key="EditorConfiguration.skipTrailingWhitespace">true</value>
    <value type="bool" key="EditorConfiguration.tintMarginArea">true</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.PluginSettings</variable>
+  <valuemap type="QVariantMap">
+   <valuemap type="QVariantMap" key="AutoTest.ActiveFrameworks">
+    <value type="bool" key="AutoTest.Framework.Boost">true</value>
+    <value type="bool" key="AutoTest.Framework.CTest">false</value>
+    <value type="bool" key="AutoTest.Framework.Catch">true</value>
+    <value type="bool" key="AutoTest.Framework.GTest">true</value>
+    <value type="bool" key="AutoTest.Framework.QtQuickTest">true</value>
+    <value type="bool" key="AutoTest.Framework.QtTest">true</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="AutoTest.CheckStates"/>
+   <value type="int" key="AutoTest.RunAfterBuild">0</value>
+   <value type="bool" key="AutoTest.UseGlobal">true</value>
+   <valuemap type="QVariantMap" key="ClangTools">
+    <value type="bool" key="ClangTools.AnalyzeOpenFiles">true</value>
+    <value type="bool" key="ClangTools.BuildBeforeAnalysis">true</value>
+    <value type="QString" key="ClangTools.DiagnosticConfig">Builtin.DefaultTidyAndClazy</value>
+    <value type="int" key="ClangTools.ParallelJobs">4</value>
+    <value type="bool" key="ClangTools.PreferConfigFile">true</value>
+    <valuelist type="QVariantList" key="ClangTools.SelectedDirs"/>
+    <valuelist type="QVariantList" key="ClangTools.SelectedFiles"/>
+    <valuelist type="QVariantList" key="ClangTools.SuppressedDiagnostics"/>
+    <value type="bool" key="ClangTools.UseGlobalSettings">true</value>
+   </valuemap>
   </valuemap>
  </data>
  <data>
@@ -214,11 +241,13 @@
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="bool" key="PE.EnvironmentAspect.PrintOnRun">false</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.CustomExecutableRunConfiguration</value>
-    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:C:/Users/abdal/OneDrive/Documents/GitHub/Lawyer_Assistant_App/LAA/LAA.pro</value>
+    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">C:/Users/abdal/OneDrive/Documents/GitHub/Lawyer_Assistant_App/LAA/LAA.pro</value>
     <value type="bool" key="ProjectExplorer.RunConfiguration.Customized">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">C:/Users/abdal/OneDrive/Desktop/LAA/Code/build-LAA-Desktop_Qt_6_6_1_MinGW_64_bit-Debug</value>
    </valuemap>
    <value type="qlonglong" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
   </valuemap>

--- a/LAA/chat.cpp
+++ b/LAA/chat.cpp
@@ -1,0 +1,39 @@
+#include "chat.h"
+
+// Constructor
+Chat::Chat(const QString& id, const QString& request, const QString& response, const QString& conversationId)
+    : id(id), request(request), response(response), conversationId(conversationId) {}
+
+// Getters
+const QString& Chat::getId() const {
+    return id;
+}
+
+const QString& Chat::getRequest() const {
+    return request;
+}
+
+const QString& Chat::getResponse() const {
+    return response;
+}
+
+const QString& Chat::getConversationId() const {
+    return conversationId;
+}
+
+// Setters
+void Chat::setId(const QString& newId) {
+    id = newId;
+}
+
+void Chat::setRequest(const QString& newRequest) {
+    request = newRequest;
+}
+
+void Chat::setResponse(const QString& newResponse) {
+    response = newResponse;
+}
+
+void Chat::setConversationId(const QString& newConversationId) {
+    conversationId = newConversationId;
+}

--- a/LAA/chat.h
+++ b/LAA/chat.h
@@ -1,0 +1,30 @@
+#ifndef CHAT_H
+#define CHAT_H
+
+#include <QString>
+
+class Chat {
+private:
+    QString id;
+    QString request;
+    QString response;
+    QString conversationId;
+
+public:
+    // Constructor
+    Chat(const QString& id, const QString& request, const QString& response, const QString& conversationId);
+
+    // Getters
+    const QString& getId() const;
+    const QString& getRequest() const;
+    const QString& getResponse() const;
+    const QString& getConversationId() const;
+
+    // Setters
+    void setId(const QString& newId);
+    void setRequest(const QString& newRequest);
+    void setResponse(const QString& newResponse);
+    void setConversationId(const QString& newConversationId);
+};
+
+#endif // CHAT_H

--- a/LAA/conversation.cpp
+++ b/LAA/conversation.cpp
@@ -1,0 +1,14 @@
+#include "conversation.h"
+
+// Constructor
+Conversation::Conversation(const QString& id) : id(id) {}
+
+// Getter for id
+const QString& Conversation::getId() const {
+    return id;
+}
+
+// Setter for id
+void Conversation::setId(const QString& newId) {
+    id = newId;
+}

--- a/LAA/conversation.h
+++ b/LAA/conversation.h
@@ -1,0 +1,21 @@
+#ifndef CONVERSATION_H
+#define CONVERSATION_H
+
+#include <QString>
+
+class Conversation {
+private:
+    QString id;
+
+public:
+    // Constructor
+    Conversation(const QString& id);
+
+    // Getter for id
+    const QString& getId() const;
+
+    // Setter for id
+    void setId(const QString& newId);
+};
+
+#endif // CONVERSATION_H


### PR DESCRIPTION
…onversation

frontend/feat/#8/conversation_chat_classes: Adding Classes Chat And Conversation

This commit introduces the Chat and Conversation classes to the frontend codebase. The Chat class encapsulates properties such as id, request, response, and conversationId, along with getter and setter methods for each attribute. Similarly, the Conversation class is designed with a QString id and corresponding getter and setter methods.

These classes provide a foundation for handling chat-related functionalities within the frontend, paving the way for seamless integration with the rest of the application. This change addresses the feature request #8.